### PR TITLE
Fix clearing search input to cancel debounced calls

### DIFF
--- a/src/feature/posts/model/hooks/useSearchPosts.ts
+++ b/src/feature/posts/model/hooks/useSearchPosts.ts
@@ -55,8 +55,11 @@ export function useSearchPosts() {
     if (textQuery.trim()) {
       debouncedTitleSearch(textQuery)
       bodyQuery.value = ''
-    } else if (!bodyQuery.value.trim()) {
-      searchResults.value = null
+    } else {
+      debouncedTitleSearch.cancel()
+      if (!bodyQuery.value.trim()) {
+        searchResults.value = null
+      }
     }
   })
 
@@ -68,8 +71,11 @@ export function useSearchPosts() {
     if (textQuery.trim()) {
       debouncedBodySearch(textQuery)
       titleQuery.value = ''
-    } else if (!titleQuery.value.trim()) {
-      searchResults.value = null
+    } else {
+      debouncedBodySearch.cancel()
+      if (!titleQuery.value.trim()) {
+        searchResults.value = null
+      }
     }
   })
 


### PR DESCRIPTION
## Summary
- cancel debounced search when clearing titleQuery or bodyQuery
- reset results if both search fields are empty

## Testing
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm format` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68455e0a90a083239edc19b7fb80f495