### PR TITLE
Update posts pagination

### DIFF
--- a/src/feature/posts/ui/PostsList.vue
+++ b/src/feature/posts/ui/PostsList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { usePosts, useSearchPosts } from '@/feature/posts/model/hooks'
 import MultiIcons from '@/shared/ui/icons/MultiIcons.vue'
 import type { Article } from '@/feature/posts/model/types'
@@ -74,6 +74,10 @@ const visiblePages = computed(() => {
     }
   }
   return pages
+})
+
+watch([searchResults, explicitIdResult], () => {
+  currentPage.value = 1
 })
 </script>
 
@@ -157,9 +161,9 @@ const visiblePages = computed(() => {
         {{ page }}
       </button>
 
-      <button :disabled="currentPage === totalPages" @click="currentPage++">Next</button>
+      <button :disabled="currentPage === displayedTotalPages" @click="currentPage++">Next</button>
 
-      <button :disabled="currentPage === totalPages" @click="currentPage = totalPages">>></button>
+      <button :disabled="currentPage === displayedTotalPages" @click="currentPage = displayedTotalPages">>></button>
     </section>
   </section>
 </template>

--- a/src/feature/posts/ui/PostsList.vue
+++ b/src/feature/posts/ui/PostsList.vue
@@ -27,7 +27,7 @@ const filteredPosts = computed<Article[]>(() => {
   if (explicitIdResult.value) return [explicitIdResult.value]
 
   const base = searchResults.value ?? posts.value
-  return base
+  const filtered = base
     .filter((p) => {
       const v = filterByLikes.value.trim()
       if (!v) return true
@@ -40,6 +40,13 @@ const filteredPosts = computed<Article[]>(() => {
       const n = Number(v)
       return !isNaN(n) && p.reactions.dislikes === n
     })
+
+  if (searchResults.value) {
+    const start = (currentPage.value - 1) * limit.value
+    return filtered.slice(start, start + limit.value)
+  }
+
+  return filtered
 })
 
 // Открыть модальное окно


### PR DESCRIPTION
## Summary
- reset page to 1 when search results change
- disable pagination buttons based on displayedTotalPages

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*
- `pnpm type-check` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68456d46fb448323b288ec318cb91065